### PR TITLE
chore: added `MIRACUM` github url

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -24,7 +24,7 @@ Die Umsetzungen im Rahmen der MII werden maßgeblich von den Universitätsklinik
 
 * MII-Konsortium DIFUTURE
 * [MII-Konsortium HiGHmed](https://github.com/orgs/medizininformatik-initiative/teams/highmed)
-* MII-Konsortium MIRACUM
+* [MII-Konsortium MIRACUM](https://github.com/miracum)
 * [MII-Konsortium SMITH](https://github.com/orgs/medizininformatik-initiative/teams/smith)
 
 ----


### PR DESCRIPTION
Some of the other urls seem to be outdated.